### PR TITLE
Added support for DrupalSecure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,13 +16,16 @@ RUN apk add --no-cache \
   php7-zlib \
   curl \
   patch \
+  git \
   && ln -s /usr/bin/php7 /usr/bin/php \
   && curl -sS https://getcomposer.org/installer | php -- --filename=composer --install-dir=/usr/bin \
   && composer global require drupal/coder \
   && ln -s /root/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcs /usr/bin/phpcs \
   && ln -s /root/.composer/vendor/squizlabs/php_codesniffer/scripts/phpcbf /usr/bin/phpcbf \
   && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/Drupal /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Drupal \
-  && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/DrupalPractice /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalPractice
+  && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/DrupalPractice /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalPractice \
+  && git clone --branch master https://git.drupal.org/sandbox/coltrane/1921926.git /root/drupalsecure_code_sniffs \
+  && ln -s /root/drupalsecure_code_sniffs/DrupalSecure /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalSecure
 
 VOLUME /work
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache \
   && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/Drupal /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Drupal \
   && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/DrupalPractice /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalPractice \
   && git clone --branch master https://git.drupal.org/sandbox/coltrane/1921926.git /root/drupalsecure_code_sniffs \
+  && cd /root/drupalsecure_code_sniffs && curl https://www.drupal.org/files/issues/parenthesis_closer_notice-2320623-2.patch | git apply && cd \
   && ln -s /root/drupalsecure_code_sniffs/DrupalSecure /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalSecure
 
 VOLUME /work

--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ To call phpcbf you need to override default command
 docker run --rm -v $(pwd):/work skilldlabs/docker-phpcs-drupal phpcbf --standard=Drupal .
 ```
 
+To call DrupalSecure check (https://www.drupal.org/sandbox/coltrane/1921926)
+```
+docker run --rm -v $(pwd):/work skilldlabs/docker-phpcs-drupal phpcs --standard=DrupalSecure .
+```
+
 ## Shortening of container name
 
 ```


### PR DESCRIPTION
There is a project which Drupal.org uses when creating a project (besides Drupal coding standard check) which checks common security issues. 

It would be nice to have it in this docker image.

docker run --rm -v $(pwd):/work skilldlabs/docker-phpcs-drupal phpcbf --standard=DrupalSecure
https://www.drupal.org/sandbox/coltrane/1921926