### PR TITLE
Upgrade Alpine to 3.10 and phpmd-phpcpd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.10
 
 ARG BUILD_DATE
 ARG VCS_REF
@@ -19,6 +19,7 @@ RUN set -e \
   php7 \
   php7-apcu \
   php7-ctype \
+  php7-dom \
   php7-json \
   php7-mbstring \
   php7-opcache \
@@ -26,21 +27,23 @@ RUN set -e \
   php7-phar \
   php7-simplexml \
   php7-tokenizer \
+  php7-xml \
   php7-xmlwriter \
-  php7-zlib \
   && curl -sS https://getcomposer.org/installer | php -- --filename=composer --install-dir=/usr/bin \
-  && composer global require drupal/coder --update-no-dev --no-suggest --prefer-dist ^8.2 \
+  && composer global require drupal/coder ^8.3.2 phpmd/phpmd ^2 sebastian/phpcpd ^4 --update-no-dev --no-suggest --prefer-dist \
   && ln -s /root/.composer/vendor/bin/phpcs /usr/bin/phpcs \
   && ln -s /root/.composer/vendor/bin/phpcbf /usr/bin/phpcbf \
-  && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/Drupal /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/Drupal \
-  && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/DrupalPractice /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalPractice \
+  && ln -s /root/.composer/vendor/bin/phpmd /usr/bin/phpmd \
+  && ln -s /root/.composer/vendor/bin/phpcpd /usr/bin/phpcpd \
+  && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/Drupal /root/.composer/vendor/squizlabs/php_codesniffer/src/Standards/Drupal \
+  && ln -s /root/.composer/vendor/drupal/coder/coder_sniffer/DrupalPractice /root/.composer/vendor/squizlabs/php_codesniffer/src/Standards/DrupalPractice \
   && cd /root/.composer/vendor/drupal/coder && curl https://www.drupal.org/files/issues/2857856-8.patch | patch -p1 && cd \
-  && git clone --branch master https://git.drupal.org/sandbox/coltrane/1921926.git /root/drupalsecure_code_sniffs \
+  && git clone --branch master https://git.drupalcode.org/sandbox/coltrane-1921926.git /root/drupalsecure_code_sniffs \
   && rm -rf /root/drupalsecure_code_sniffs/.git \
   && cd /root/drupalsecure_code_sniffs && curl https://www.drupal.org/files/issues/parenthesis_closer_notice-2320623-2.patch | git apply && cd \
   && apk del --no-cache git \
   && rm -rf /root/.composer/cache/* \
-  && ln -s /root/drupalsecure_code_sniffs/DrupalSecure /root/.composer/vendor/squizlabs/php_codesniffer/CodeSniffer/Standards/DrupalSecure \
+  && ln -s /root/drupalsecure_code_sniffs/DrupalSecure /root/.composer/vendor/squizlabs/php_codesniffer/src/Standards/DrupalSecure \
   && sed -i "s/.*memory_limit = .*/memory_limit = -1/" /etc/php7/php.ini
 
 VOLUME /work

--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@ set -e -x
 docker build --pull \
   --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
   --build-arg VCS_REF=`git rev-parse --short HEAD` \
-  -t skilldlabs/docker-phpcs-drupal .
+  -t skilldlabs/docker-phpcs-drupal:next .
 
 docker build --pull \
   --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \


### PR DESCRIPTION
Php 7.1 is most stable in Alpine 3.7
phpmd & phpcpd adds 4mb to image https://hub.docker.com/r/skilldlabs/docker-phpcs-drupal/tags/ *next*

- https://github.com/sebastianbergmann/phpcpd
- https://github.com/phpmd/phpmd